### PR TITLE
Metric VNode Repair window

### DIFF
--- a/apps/metric_vnode/src/metric_vnode.erl
+++ b/apps/metric_vnode/src/metric_vnode.erl
@@ -132,40 +132,40 @@ handle_command({repair, Bucket, Metric, Time, Value}, _Sender,
         {true, State1} ->
             State2 =
                 case ets:lookup(T, {Bucket, Metric}) of
-                    %% If we repear ona a place before the metric, well just
+                    %% If we repair on a place before the metric, we will just
                     %% write it!
                     [{{Bucket, Metric}, Start, _Size, _Time, _Array}]
                       when Time + Count < Start ->
                         metric_io:write(State#state.io, Bucket, Metric, Time,
                                         Value),
                         State1;
-                    %% The data is entirely behind the cache, so we flush the
-                    %% cache and use the repair request as new cache
+                    %% The data is entirely ahead of the cache, so we flush the
+                    %% cache and use the repair request as new the cache.
                     [{{Bucket, Metric}, Start, Size, _Time, Array}]
-                      when Start + Size > Time ->
+                      when Time > Start + Size ->
                         Bin = k6_bytea:get(Array, 0, Size * ?DATA_SIZE),
                         k6_bytea:delete(Array),
                         ets:delete(T, {Bucket, Metric}),
                         metric_io:write(State#state.io, Bucket, Metric, Start,
                                         Bin),
                         do_put(Bucket, Metric, Time, Value, State);
-                    %% Now it gets tricky teh repair is intersecting with the
-                    %% cache this should never happen but it probably will, so
+                    %% Now it gets tricky. The repair intersects with the
+                    %% cache - this should never happen but it probably will, so
                     %% it sucks!  There is no sane way to merge the values if
-                    %% they intersect,  however we know the following:
-                    %% 1) A repari request, based on how it is build, will never
-                    %%    contain unset values.
+                    %% they intersect, however we know the following:
+                    %% 1) A repair request, based on how it is built, will never
+                    %%    contain unset(empty) values.
                     %% 2) A cache can be an entirely empty value or contain
-                    %%    empty    segments.
-                    %% Based on that the best aproach is to flush the cache and
-                    %% then also flush the repair request. So that nothing will
-                    %% be overwritten with a empty value.
+                    %%    empty segments.
+                    %% Based on that, the best approach is to flush the cache and
+                    %% then also to flush the repair request. This ensures that
+                    %% nothing will be overwritten with a empty value.
                     %%
-                    %% - Flusing the repair once could lead to emptyies in the
-                    %%   cache overwriting non emptyies from the repair.
+                    %% - Flusing the repair once could lead to empties in the
+                    %%   cache overwriting non-empties from the repair.
                     %% - Flushing the cache and caching the repair could lead to
-                    %%   new emplties in the new caceh from the repair now
-                    %%   overwriting non empties from the privious cache.
+                    %%   new empties in the new cache from the repair now
+                    %%   overwriting non-empties from the previous cache.
                     [{{Bucket, Metric}, Start, Size, _Time, Array}] ->
                         Bin = k6_bytea:get(Array, 0, Size * ?DATA_SIZE),
                         k6_bytea:delete(Array),


### PR DESCRIPTION
@Licenser I would like to clarify my understanding of the boundary checking within the handling of the repair command within the Metric VNode.  
I would like to use illustrations along the way, hopefully this will help in articulating my point.  All cases assume that the cache contains values for the given Bucket and Metric pair. 

![image](https://cloud.githubusercontent.com/assets/164431/11538352/8b11a6be-9919-11e5-947b-fc95bcba3d9e.png)

![image](https://cloud.githubusercontent.com/assets/164431/11538406/ddf4c0f0-9919-11e5-8e6e-21c3beec81a4.png)

![image](https://cloud.githubusercontent.com/assets/164431/11538447/0500e200-991a-11e5-85e2-77e7dc63c0e7.png)

I feel that there is overlap between conditions 2 and 3, and would like to propose the following amended condition 2 (in accordance with my understanding):

![image](https://cloud.githubusercontent.com/assets/164431/11538517/4102d29a-991a-11e5-8eef-b8cdb02e8132.png)

I assume that the number of points residing in the ETS cache does not have to be the same as the number of points in a repair, seeing as a repair could be propagated in response to a range query (with variable size).  Does clearing the cache before flushing to disk increase the chances of data loss, if writing to the file system fails.  

I would be grateful if you could also address what you refer to as an intersection for the cache and repair data. Are you referring to the case where at least one value overlaps? 

Thanks.



