### PR TITLE
Correct minor typo in ddb-admin

### DIFF
--- a/rel/files/ddb-admin
+++ b/rel/files/ddb-admin
@@ -386,7 +386,7 @@ cluster_admin()
             ;;
         status)
             node_up_check
-            $NODETOOL rpc riak_core_console command riak-admin cluster $@riak
+            $NODETOOL rpc riak_core_console command riak-admin cluster $@
             ;;
         partitions|partition)
             node_up_check


### PR DESCRIPTION
Previously, the cluster status command would not work - it now works as required:

```sh
.../_build/default/rel/ddb (test)$ ./bin/ddb-admin cluster status
---- Cluster Status ----
Ring ready: true

+-----------------------------+-------+-------+-----+-------+
|            node             |status | avail |ring |pending|
+-----------------------------+-------+-------+-----+-------+
|     dalmatinerdb1@127.0.0.2 |joining|  up   |  0.0|  --   |
| (C) dalmatinerdb@127.0.0.1  | valid |  up   |100.0|  --   |
+-----------------------------+-------+-------+-----+-------+

Key: (C) = Claimant; availability marked with '!' is unexpected

```