### PR TITLE
Hinted handoff bug

### DIFF
--- a/apps/metric_vnode/src/metric_vnode.erl
+++ b/apps/metric_vnode/src/metric_vnode.erl
@@ -469,23 +469,24 @@ valid_ts(TS, Bucket, State) ->
         %% TODO:
         %% We ignore every data where the last point is older then the
         %% lifetime this means we could still potentially write in the
-        %% past if writing baches but this is a problem for another day!
+        %% past if writing batches but this is a problem for another day!
         {Exp, State1} when is_integer(Exp),
                            TS < Exp ->
             {false, State1};
         {_, State1} ->
             {true, State1}
     end.
+
 %% Return the latest point we'd ever want to save. This is more strict
 %% then the expiration we do on the data but it is strong enough for
 %% our guarantee.
 expiry(Bucket, State) ->
-    Now = erlang:system_time(milli_seconds),
     case get_lifetime(Bucket, State) of
         {infinity, State1} ->
             {infinity, State1};
         {LT, State1} ->
             {Res, State2} = get_resolution(Bucket, State1),
+            Now = erlang:system_time(milli_seconds),
             Exp = (Now - LT) div Res,
             {Exp, State2}
     end.


### PR DESCRIPTION
The hinted handoff process is triggered once a vnode enters an inactive state. This happens when the current active state times out, for a period of anywhere between 60s and 120s. basho/riak_core#715

A metric_vnode updates it's current time on a 1s tick, which is used to determine if a metric has a valid timestamp. This has the side effect of prolonging the active state, preventing the vnode from becoming idle.

Instead, the timestamp is now recreated on every invocation to the expiry function, allowing the tick message to be removed.