### PR TITLE
Return partition and nodename as tuple when replying to the read FSM

### DIFF
--- a/apps/metric_vnode/eqc/metric_vnode_eqc.erl
+++ b/apps/metric_vnode/eqc/metric_vnode_eqc.erl
@@ -7,8 +7,6 @@
 -compile(export_all).
 
 -define(DIR, ".qcdata").
--define(T, gb_trees).
--define(V, metric_vnode).
 -define(B, <<"bucket">>).
 -define(M, <<"metric">>).
 
@@ -26,19 +24,19 @@ tree_set(Tr, _T, []) ->
     Tr;
 
 tree_set(Tr, T, [V | R]) ->
-    Tr1 = ?T:enter(T, V, Tr),
+    Tr1 = gb_trees:enter(T, V, Tr),
     tree_set(Tr1, T+1, R).
 
 new() ->
-    {ok, S, _} = ?V:init([0]),
-    T = ?T:empty(),
+    {ok, S, _} = metric_vnode:init([0]),
+    T = gb_trees:empty(),
     {S, T}.
 
 repair({S, Tr}, T, Vs) ->
     case overlap(Tr, T, Vs) of
         [] ->
             Command = {repair, ?B, ?M, T, mmath_bin:from_list(Vs)},
-            {noreply, S1} = ?V:handle_command(Command, sender, S),
+            {noreply, S1} = metric_vnode:handle_command(Command, sender, S),
             Tr1 = tree_set(Tr, T, Vs),
             {S1, Tr1};
         _ ->
@@ -49,7 +47,7 @@ put({S, Tr}, T, Vs) ->
     case overlap(Tr, T, Vs) of
         [] ->
             Command = {put, ?B, ?M, {T, mmath_bin:from_list(Vs)}},
-            {reply, ok, S1} = ?V:handle_command(Command, sender, S),
+            {reply, ok, S1} = metric_vnode:handle_command(Command, sender, S),
             Tr1 = tree_set(Tr, T, Vs),
             {S1, Tr1};
         _ ->
@@ -60,7 +58,7 @@ mput({S, Tr}, T, Vs) ->
     case overlap(Tr, T, Vs) of
         [] ->
             Command = {mput, [{?B, ?M, T, mmath_bin:from_list(Vs)}]},
-            {reply, ok, S1} = ?V:handle_command(Command, sender, S),
+            {reply, ok, S1} = metric_vnode:handle_command(Command, sender, S),
             Tr1 = tree_set(Tr, T, Vs),
             {S1, Tr1};
         _ ->
@@ -69,14 +67,14 @@ mput({S, Tr}, T, Vs) ->
 
 overlap(Tr, Start, Vs) ->
     End = Start + length(Vs),
-    [T || {T, _} <- ?T:to_list(Tr),
+    [T || {T, _} <- gb_trees:to_list(Tr),
           T >= Start, T =< End].
 
 get(S, T, C) ->
     ReqID = T,
     ReplyNode = nonode@nohost,
     Command = {get, ReqID, ?B, ?M, {T, C}},
-    case ?V:handle_command(Command, {raw, ReqID, self()}, S) of
+    case metric_vnode:handle_command(Command, {raw, ReqID, self()}, S) of
         {noreply, _S1} ->
             receive
                 {ReqID, {ok, ReqID, {_Partition, ReplyNode}, D}} ->
@@ -90,7 +88,7 @@ get(S, T, C) ->
     end.
 
 vnode() ->
-    ?SIZED(Size,vnode(Size)).
+    ?SIZED(Size, vnode(Size)).
 
 non_empty_list(T) ->
     ?SUCHTHAT(L, list(T), L =/= []).
@@ -99,15 +97,16 @@ values() ->
     {offset(), non_empty_list(non_z_int())}.
 
 vnode(Size) ->
+    S = Size,
     ?LAZY(oneof(
-            [{call, ?MODULE, new, []} || Size == 0]
+            [{call, ?MODULE, new, []} || S == 0]
             ++ [?LETSHRINK(
-                   [V], [vnode(Size-1)],
+                   [V], [vnode(S-1)],
                    ?LET({T, Vs}, values(),
                         oneof(
                           [{call, ?MODULE, put, [V, T, Vs]},
                            {call, ?MODULE, mput, [V, T, Vs]},
-                           {call, ?MODULE, repair, [V, T, Vs]}])))  || Size > 0])).
+                           {call, ?MODULE, repair, [V, T, Vs]}]))) || S > 0])).
 %%%-------------------------------------------------------------------
 %%% Properties
 %%%-------------------------------------------------------------------
@@ -120,12 +119,12 @@ prop_gb_comp() ->
                    os:cmd("rm -r data"),
                    os:cmd("mkdir data"),
                    {S, T} = eval(D),
-                   List = ?T:to_list(T),
+                   List = gb_trees:to_list(T),
                    List1 = [{get(S, Time, 1), V} || {Time, V} <- List],
-                   List2 = [{unlist(mmath_bin:to_list(Vs)), Vt} || {{_ ,Vs}, Vt} <- List1],
+                   List2 = [{unlist(Vs), Vt} || {{_ , Vs}, Vt} <- List1],
                    List3 = [true || {_V, _V} <- List2],
                    Len = length(List),
-                   ?V:terminate(normal, S),
+                   metric_vnode:terminate(normal, S),
                    ?WHENFAIL(io:format(user,
                                        "L : ~p~n"
                                        "L1: ~p~n"
@@ -144,17 +143,17 @@ prop_is_empty() ->
                    os:cmd("rm -r data"),
                    os:cmd("mkdir data"),
                    {S, T} = eval(D),
-                   {Empty, _S1} = ?V:is_empty(S),
-                   TreeEmpty = ?T:is_empty(T),
+                   {Empty, _S1} = metric_vnode:is_empty(S),
+                   TreeEmpty = gb_trees:is_empty(T),
                    if
                        Empty == TreeEmpty ->
                            ok;
                        true ->
                            io:format(user, "~p == ~p~n", [S, T])
                    end,
-                   ?V:terminate(normal, S),
-                   ?WHENFAIL(io:format(user, "L: ~p /= ~p~n", [Empty, TreeEmpty]),
-                             Empty == TreeEmpty)
+                   metric_vnode:terminate(normal, S),
+                   ?WHENFAIL(io:format(user, "L: ~p /= ~p~n",
+                                       [Empty, TreeEmpty]), Empty == TreeEmpty)
                end)).
 
 prop_empty_after_delete() ->
@@ -165,9 +164,9 @@ prop_empty_after_delete() ->
                    os:cmd("rm -r data"),
                    os:cmd("mkdir data"),
                    {S, _T} = eval(D),
-                   {ok, S1} = ?V:delete(S),
-                   {Empty, _S3} = ?V:is_empty(S1),
-                   ?V:terminate(normal, S),
+                   {ok, S1} = metric_vnode:delete(S),
+                   {Empty, _S3} = metric_vnode:is_empty(S1),
+                   metric_vnode:terminate(normal, S),
                    Empty == true
                end)).
 
@@ -180,53 +179,56 @@ prop_handoff() ->
                    os:cmd("mkdir data"),
                    {S, T} = eval(D),
 
-                   List = ?T:to_list(T),
+                   List = gb_trees:to_list(T),
 
                    List1 = [{get(S, Time, 1), V} || {Time, V} <- List],
-                   List2 = [{unlist(mmath_bin:to_list(Vs)), Vt} || {{_ ,Vs}, Vt} <- List1],
+                   List2 = [{unlist(Vs), Vt} || {{_ , Vs}, Vt} <- List1],
                    List3 = [true || {_V, _V} <- List2],
 
                    Fun = fun(K, V, A) ->
-                                 [?V:encode_handoff_item(K, V) | A]
+                                 [metric_vnode:encode_handoff_item(K, V) | A]
                          end,
                    FR = ?FOLD_REQ{foldfun=Fun, acc0=[]},
                    {async, {fold, AsyncH, _}, _, S1} =
-                       ?V:handle_handoff_command(FR, self(), S),
+                       metric_vnode:handle_handoff_command(FR, self(), S),
                    L = AsyncH(),
                    L1 = lists:sort(L),
-                   {ok, C, _} = ?V:init([1]),
+                   {ok, C, _} = metric_vnode:init([1]),
                    C1 = lists:foldl(fun(Data, SAcc) ->
-                                            {reply, ok, SAcc1} = ?V:handle_handoff_data(Data, SAcc),
+                                            {reply, ok, SAcc1} =
+                                                handoff_recv(Data, SAcc),
                                             SAcc1
                                     end, C, L1),
 
                    List4 = [{get(C1, Time, 1), V} || {Time, V} <- List],
-                   List5 = [{unlist(mmath_bin:to_list(Vs)), Vt} || {{_ ,Vs}, Vt} <- List1],
+                   List5 = [{unlist(Vs), Vt} || {{_ , Vs}, Vt} <- List1],
                    List6 = [true || {_V, _V} <- List2],
 
-                   {async,{fold, AsyncHc, _}, _, C2} =
-                       ?V:handle_handoff_command(FR, self(), C1),
+                   {async, {fold, AsyncHc, _}, _, C2} =
+                       metric_vnode:handle_handoff_command(FR, self(), C1),
                    Lc = AsyncHc(),
                    Lc1 = lists:sort(Lc),
-                   {async,{fold, Async, _}, _, _} =
-                       ?V:handle_coverage({metrics, ?B}, all, self(), S1),
+                   {async, {fold, Async, _}, _, _} =
+                       metric_vnode:handle_coverage({metrics, ?B},
+                                                    all, self(), S1),
                    Ms = Async(),
-                   {async,{fold, AsyncC, _}, _, _} =
-                       ?V:handle_coverage({metrics, ?B}, all, self(), C2),
+                   {async, {fold, AsyncC, _}, _, _} =
+                       metric_vnode:handle_coverage({metrics, ?B},
+                                                    all, self(), C2),
                    MsC = AsyncC(),
 
                    Len = length(List),
 
 
-                   ?V:terminate(normal, S1),
-                   ?V:terminate(normal, C2),
+                   metric_vnode:terminate(normal, S1),
+                   metric_vnode:terminate(normal, C2),
 
                    ?WHENFAIL(io:format(user, "L: ~p /= ~p~n"
                                        "M: ~p /= ~p~n",
                                        [Lc1, L1, gb_sets:to_list(MsC),
                                         gb_sets:to_list(Ms)]),
                              Lc1 == L1 andalso
-                             btrie:fetch_keys(MsC) == btrie:fetch_keys(Ms) andalso
+                             fetch_keys(MsC) == fetch_keys(Ms) andalso
                              length(List1) == Len andalso
                              length(List2) == Len andalso
                              length(List3) == Len andalso
@@ -240,8 +242,15 @@ prop_handoff() ->
 %%% Helper
 %%%-------------------------------------------------------------------
 
-unlist([E]) ->
-    E.
+unlist(Vs) ->
+    [Inner] = mmath_bin:to_list(Vs),
+    Inner.
+
+fetch_keys(T) ->
+    btrie:fetch_keys(T).
+
+handoff_recv(Data, SAcc) ->
+    metric_vnode:handle_handoff_data(Data, SAcc).
 
 setup_fn() ->
     setup(),

--- a/apps/metric_vnode/eqc/metric_vnode_eqc.erl
+++ b/apps/metric_vnode/eqc/metric_vnode_eqc.erl
@@ -74,19 +74,18 @@ overlap(Tr, Start, Vs) ->
 
 get(S, T, C) ->
     ReqID = T,
+    ReplyNode = nonode@nohost,
     Command = {get, ReqID, ?B, ?M, {T, C}},
     case ?V:handle_command(Command, {raw, ReqID, self()}, S) of
         {noreply, _S1} ->
             receive
-                {ReqID, {ok, ReqID, _, D}} ->
+                {ReqID, {ok, ReqID, {_Partition, ReplyNode}, D}} ->
                     D
             after
                 1000 ->
                     timeout
             end;
-        {reply, {ok, _, _, Reply}, _S1} ->
-            Reply;
-        {reply, {ok, Reply}, _S1} ->
+        {reply, {ok, _, {_Partition, ReplyNode}, Reply}, _S1} ->
             Reply
     end.
 

--- a/rebar.lock
+++ b/rebar.lock
@@ -20,7 +20,7 @@
   0},
  {<<"cuttlefish">>,
   {git,"https://github.com/tsloughter/cuttlefish.git",
-       {ref,"f5f6fdc1b0dd8ebe909b81f0b38f5715d4e869e6"}},
+       {ref,"bd2660f6e090e88556baf203b2769b9319a780d5"}},
   0},
  {<<"dproto">>,
   {git,"https://github.com/DalmatinerDB/dproto.git",


### PR DESCRIPTION
When a get request is serviced from cache, the metric vnode responds with information about it's partition, but not the nodename. This information is used by the read FSM to issue commands to repair any data that is in conflict.

This PR fixes/enforces the 2-tuple convention that is required by riak-core, when issuing a command. This is only enforced on a get, since the rest of the commands seem to use a well formed preference list (a list of 2 tuples). The repair scenario seems to be the only case where a destination tuple singleton is used to address a command to a specific VNode directly, by dalmatiner.