### PR TITLE
Stop flushing cache content when reading

### DIFF
--- a/apps/metric_vnode/src/metric_io.erl
+++ b/apps/metric_vnode/src/metric_io.erl
@@ -10,11 +10,13 @@
 
 -behaviour(gen_server).
 
+-include_lib("mmath/include/mmath.hrl").
+
 %% API
 -export([start_link/1,
          empty/1, fold/3, delete/1, delete/2, delete/3, close/1,
          buckets/1, metrics/2, metrics/3,
-         read/7, write/5, write/6]).
+         read/7, read_rest/8, write/5, write/6]).
 
 %% gen_server callbacks
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2,
@@ -62,6 +64,9 @@ swrite(Pid, Bucket, Metric, Time, Value) ->
 
 read(Pid, Bucket, Metric, Time, Count, ReqID, Sender) ->
     gen_server:cast(Pid, {read, Bucket, Metric, Time, Count, ReqID, Sender}).
+
+read_rest(Pid, Bucket, Metric, Time, Count, Part, ReqID, Sender) ->
+    gen_server:cast(Pid, {read_rest, Bucket, Metric, Time, Count, Part, ReqID, Sender}).
 
 buckets(Pid) ->
     gen_server:call(Pid, buckets).
@@ -385,17 +390,27 @@ handle_cast({write, Bucket, Metric, Time, Value}, State) ->
 
 handle_cast({read, Bucket, Metric, Time, Count, ReqID, Sender},
             State = #state{node = N, partition = P}) ->
-    {D, State1} =
-        case get_set(Bucket, State) of
-            {ok, {{Resolution, MSet}, S2}} ->
-                {ok, Data} = mstore:get(MSet, Metric, Time, Count),
-                {{Resolution, Data}, S2};
-            _ ->
-                lager:warning("[IO] Unknown metric: ~p/~p", [Bucket, Metric]),
-                Resolution = get_resolution(Bucket),
-                {{Resolution, mmath_bin:empty(Count)}, State}
-        end,
+    {D, State1} = do_read(Bucket, Metric, Time, Count, State),
     riak_core_vnode:reply(Sender, {ok, ReqID, {P, N}, D}),
+    {noreply, State1};
+
+handle_cast({read_rest, Bucket, Metric, Time, Count, Part, ReqID, Sender},
+            State = #state{node = N, partition = P}) ->
+    {Data, State1} =
+        case Part of
+            {Offset, PCount, Bin} when Offset =:= 0 ->
+                {{Res, D}, S} = do_read(Bucket, Metric, Time + PCount, Count - PCount, State),
+                {{Res, <<Bin/binary, D/binary>>}, S};
+            {Offset, PCount, Bin} when Offset + PCount =:= Count ->
+                {{Res, D}, S} = do_read(Bucket, Metric, Time, Count - PCount, State),
+                {{Res, <<D/binary, Bin/binary>>}, S};
+            {Offset, PCount, Bin} ->
+                {{Res, D}, S} = do_read(Bucket, Metric, Time, Count, State),
+                D1 = binary_part(D, 0, Offset * ?DATA_SIZE),
+                D2 = binary_part(D, Count * ?DATA_SIZE, (Offset + PCount - Count) * ?DATA_SIZE),
+                {{Res, <<D1/binary, Bin/binary, D2/binary>>}, S}
+        end,
+    riak_core_vnode:reply(Sender, {ok, ReqID, {P, N}, Data}),
     {noreply, State1};
 
 handle_cast(_Msg, State) ->
@@ -539,3 +554,14 @@ get_resolution(Bucket) ->
     dalmatiner_opt:get(
       <<"buckets">>, Bucket, <<"resolution">>,
       {metric_vnode, resolution}, 1000).
+
+do_read(Bucket, Metric, Time, Count, State) ->
+    case get_set(Bucket, State) of
+        {ok, {{Resolution, MSet}, S2}} ->
+            {ok, Data} = mstore:get(MSet, Metric, Time, Count),
+            {{Resolution, Data}, S2};
+        _ ->
+            lager:warning("[IO] Unknown metric: ~p/~p", [Bucket, Metric]),
+            Resolution = get_resolution(Bucket),
+            {{Resolution, mmath_bin:empty(Count)}, State}
+    end.

--- a/apps/metric_vnode/src/metric_vnode.erl
+++ b/apps/metric_vnode/src/metric_vnode.erl
@@ -245,7 +245,8 @@ handle_command({get, ReqID, Bucket, Metric, {Time, Count}}, Sender,
             Bin = k6_bytea:get(Array, SkipBytes, (PartCount * ?DATA_SIZE)),
             Offset = PartStart - Time,
             Part = {Offset, PartCount, Bin},
-            metric_io:read_rest(IO, Bucket, Metric, Time, Count, Part, ReqID, Sender),
+            metric_io:read_rest(
+              IO, Bucket, Metric, Time, Count, Part, ReqID, Sender),
             {noreply, State};
         %% If we are here we know that there is either no cahce or the requested
         %% window and the cache do not overlap, so we can simply serve it from

--- a/apps/metric_vnode/src/metric_vnode.erl
+++ b/apps/metric_vnode/src/metric_vnode.erl
@@ -230,25 +230,26 @@ handle_command({get, ReqID, Bucket, Metric, {Time, Count}}, Sender,
             {Resolution, State1} = get_resolution(Bucket, State),
             {reply, {ok, ReqID, Idx, {Resolution, Data}}, State1};
         %% The request is neither before, after nor entirely inside the cache
-        %% we sadly have to flush it.
-        %% This are the conditions where we have to flush the cache and then
-        %% read it from the ui server
+        %% we have to read data, but apply cached part on top of it.
         [{BM, Start, Size, _Time, Array}]
           when
               %% The window starts before the cache but ends in it
               (Time < Start andalso Time + Count >= Start)
+
               %% The window starts inside the cahce and ends afterwards
               orelse (Time =< Start + Size andalso Time + Count > Start + Size)
               ->
-            Bin = k6_bytea:get(Array, 0, Size * ?DATA_SIZE),
-            k6_bytea:delete(Array),
-            ets:delete(T, {Bucket, Metric}),
-            metric_io:write(IO, Bucket, Metric, Start, Bin),
-            metric_io:read(IO, Bucket, Metric, Time, Count, ReqID, Sender),
+            PartStart = max(Time, Start),
+            PartCount = min(Time + Count, Start + Size) - PartStart,
+            SkipBytes = (PartStart - Start),
+            Bin = k6_bytea:get(Array, SkipBytes, (PartCount * ?DATA_SIZE)),
+            Offset = PartStart - Time,
+            Part = {Offset, PartCount, Bin},
+            metric_io:read_rest(IO, Bucket, Metric, Time, Count, Part, ReqID, Sender),
             {noreply, State};
         %% If we are here we know that there is either no cahce or the requested
         %% window and the cache do not overlap, so we can simply serve it from
-        %% the ui servers
+        %% the io servers
         _ ->
             metric_io:read(IO, Bucket, Metric, Time, Count, ReqID, Sender),
             {noreply, State}


### PR DESCRIPTION
I made a change according to suggestions in email. Main goal here is to avoid flushing buffers when data is read. I am hoping this will help us run Dalmatiner on a hardware with limited IO capacity.

I am happy to improve it if you have any suggestions.