### PR TITLE
Do not attempt to write ETS data to crashed process

### DIFF
--- a/rebar.lock
+++ b/rebar.lock
@@ -20,7 +20,7 @@
   0},
  {<<"cuttlefish">>,
   {git,"https://github.com/tsloughter/cuttlefish.git",
-       {ref,"f5f6fdc1b0dd8ebe909b81f0b38f5715d4e869e6"}},
+       {ref,"bd2660f6e090e88556baf203b2769b9319a780d5"}},
   0},
  {<<"dproto">>,
   {git,"https://github.com/DalmatinerDB/dproto.git",


### PR DESCRIPTION
Not sure about the proposed fix, do you think it is better to let it crash and burn?