### PR TITLE
Fix offest calculation when part of requested data is in memory buffer

### DIFF
--- a/apps/metric_vnode/src/metric_vnode.erl
+++ b/apps/metric_vnode/src/metric_vnode.erl
@@ -241,7 +241,7 @@ handle_command({get, ReqID, Bucket, Metric, {Time, Count}}, Sender,
               ->
             PartStart = max(Time, Start),
             PartCount = min(Time + Count, Start + Size) - PartStart,
-            SkipBytes = (PartStart - Start),
+            SkipBytes = (PartStart - Start) * ?DATA_SIZE,
             Bin = k6_bytea:get(Array, SkipBytes, (PartCount * ?DATA_SIZE)),
             Offset = PartStart - Time,
             Part = {Offset, PartCount, Bin},


### PR DESCRIPTION
I found a bug in my earlier patch to read from cache and disk simultaneously. In rare circumstances  when requested period was shorted then buffer, offset was wrongly calculated.