### PR TITLE
Make sure sudo sets user home folder when running as different user

### DIFF
--- a/rel/files/ddb
+++ b/rel/files/ddb
@@ -13,7 +13,7 @@ RUNNER_USER={{run_user}}
 
 # Make sure this script is running as the appropriate user
 if [ ! -z "$RUNNER_USER" ] && [ `whoami` != "$RUNNER_USER" ]; then
-    exec sudo -u $RUNNER_USER $0 $@
+    exec sudo -H -u $RUNNER_USER $0 $@
 fi
 
 # Make sure CWD is set to runner base dir

--- a/rel/files/ddb-admin
+++ b/rel/files/ddb-admin
@@ -14,7 +14,7 @@ RUNNER_USER={{run_user}}
 
 # Make sure this script is running as the appropriate user
 if [ ! -z "$RUNNER_USER" ] && [ `whoami` != "$RUNNER_USER" ]; then
-    exec sudo -u $RUNNER_USER $0 $@
+    exec sudo -H -u $RUNNER_USER $0 $@
 fi
 
 # Make sure CWD is set to runner base dir


### PR DESCRIPTION
On some environments scripts will fail, because erlang will complain about missing ~/.erlang.cookie.

We have that problem on ubuntu.

In my opinion making sudo change home folder to actual $RUNNER_USER will help with running it across different environments.
