### PR TITLE
Add config option to set limit of tcp connections

### DIFF
--- a/apps/dalmatiner_db/src/dalmatiner_db_app.erl
+++ b/apps/dalmatiner_db/src/dalmatiner_db_app.erl
@@ -22,8 +22,11 @@ start(_StartType, _StartArgs) ->
                     _ ->
                         100
                 end,
+    MaxConnections = application:get_env(dalmatiner_db, tcp_max_connections, 1024),
     {ok, _} = ranch:start_listener(dalmatiner_tcp, Listeners,
-                                   ranch_tcp, [{port, Port}],
+                                   ranch_tcp,
+                                   [{port, Port},
+                                    {max_connections, MaxConnections}],
                                    dalmatiner_tcp, []),
     folsom_metrics:new_histogram(put, slide, 60),
     folsom_metrics:new_histogram(mput, slide, 60),

--- a/apps/dalmatiner_db/src/dalmatiner_db_app.erl
+++ b/apps/dalmatiner_db/src/dalmatiner_db_app.erl
@@ -22,11 +22,11 @@ start(_StartType, _StartArgs) ->
                     _ ->
                         100
                 end,
-    MaxConnections = application:get_env(dalmatiner_db, tcp_max_connections, 1024),
+    MaxConn = application:get_env(dalmatiner_db, tcp_max_connections, 1024),
     {ok, _} = ranch:start_listener(dalmatiner_tcp, Listeners,
                                    ranch_tcp,
                                    [{port, Port},
-                                    {max_connections, MaxConnections}],
+                                    {max_connections, MaxConn}],
                                    dalmatiner_tcp, []),
     folsom_metrics:new_histogram(put, slide, 60),
     folsom_metrics:new_histogram(mput, slide, 60),

--- a/schema/dalmatinerdb.schema
+++ b/schema/dalmatinerdb.schema
@@ -10,6 +10,12 @@
  [{default, 100},
   {datatype, integer}]}.
 
+%% @doc Number of allowed concurrent tcp connections.
+{mapping, "tcp_max_connections", "dalmatiner_db.tcp_max_connections",
+ [{default, 1024},
+  {datatype, integer},
+  hidden]}.
+
 %% @doc The number of Asyncronous worker for a vnode.
 {mapping, "async_workers", "metric_vnode.async_workers",
  [{datatype, integer},

--- a/schema/dalmatinerdb.schema
+++ b/schema/dalmatinerdb.schema
@@ -13,8 +13,7 @@
 %% @doc Number of allowed concurrent tcp connections.
 {mapping, "tcp_max_connections", "dalmatiner_db.tcp_max_connections",
  [{default, 1024},
-  {datatype, integer},
-  hidden]}.
+  {datatype, integer}]}.
 
 %% @doc The number of Asyncronous worker for a vnode.
 {mapping, "async_workers", "metric_vnode.async_workers",


### PR DESCRIPTION
We found, that we had to extend default ranch 'max_connections' limit. I present this patch, because others may need to customise it as well. It feels like ddb.conf is good place to put those customizations.
