### PR TITLE
Set bucket resolution on stream mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,5 @@ apps/metric_db/include/metric_db_version.hrl
 _build
 TEST-*
 .rebar3
+data/
+log/

--- a/apps/dalmatiner_db/src/bkt_dict.erl
+++ b/apps/dalmatiner_db/src/bkt_dict.erl
@@ -6,7 +6,14 @@
 
 -export_type([bkt_dict/0]).
 
--record(bkt_dict, {bucket, ppf, dict, n, w, nodes, cbin}).
+-record(bkt_dict, {
+         bucket :: binary(),
+         ppf :: pos_integer(),
+         dict,
+         n :: pos_integer(),
+         w :: pos_integer(),
+         nodes,
+         cbin}).
 
 -type bkt_dict() :: #bkt_dict{}.
 

--- a/apps/metric_vnode/src/metric_vnode.erl
+++ b/apps/metric_vnode/src/metric_vnode.erl
@@ -370,7 +370,7 @@ handle_coverage({delete, Bucket}, _KeySpaces, _Sender,
     {reply, Reply, State}.
 
 handle_info(vacuum, State = #state{io = IO, partition = P}) ->
-    lager:info("[vaccum] Starting vaccum for partution ~p.", [P]),
+    lager:info("[vacuum] Starting vacuum for partution ~p.", [P]),
     {ok, Bs} = metric_io:buckets(IO),
     State1 = State#state{now = timestamp()},
     State2 =
@@ -383,7 +383,7 @@ handle_info(vacuum, State = #state{io = IO, partition = P}) ->
                                     SAcc1
                             end
                     end, State1, btrie:fetch_keys(Bs)),
-    lager:info("[vaccum] Finalized vaccum for partution ~p.", [P]),
+    lager:info("[vacuum] Finalized vacuum for partution ~p.", [P]),
     {ok, State2};
 
 handle_info({'EXIT', IO, normal}, State = #state{io = IO}) ->
@@ -469,7 +469,7 @@ do_put(Bucket, Metric, Time, Value,
                     Jitter = random:uniform(CT),
                     ets:insert(T, {BM, Time, Len, Time + Jitter, Array});
                 %% If we don't have a cache but our data is too big for the
-                %% cache we happiely write it directly
+                %% cache we happily write it directly
                 [] ->
                     metric_io:write(IO, Bucket, Metric, Time, Value, Sync)
             end,

--- a/rebar.config
+++ b/rebar.config
@@ -18,7 +18,7 @@
   trie,
   {mmath, ".*", {git, "https://github.com/DalmatinerDB/mmath.git", {branch, "0.2"}}},
   {mstore, ".*", {git, "https://github.com/DalmatinerDB/mstore.git", {branch, "master"}}},
-  {dproto, "0.1.18"},
+  {dproto, "0.1.19"},
   eper,
   recon
  ]}.

--- a/rebar.lock
+++ b/rebar.lock
@@ -4,7 +4,7 @@
  {<<"chash">>,{pkg,<<"chash">>,<<"0.1.1">>},1},
  {<<"clique">>,{pkg,<<"clique">>,<<"3.0.1">>},1},
  {<<"cuttlefish">>,{pkg,<<"cuttlefish">>,<<"2.0.7">>},1},
- {<<"dproto">>,{pkg,<<"dproto">>,<<"0.1.18">>},0},
+ {<<"dproto">>,{pkg,<<"dproto">>,<<"0.1.19">>},0},
  {<<"edown">>,{pkg,<<"edown">>,<<"0.7.0">>},0},
  {<<"eleveldb">>,{pkg,<<"eleveldb">>,<<"2.1.3">>},1},
  {<<"eper">>,{pkg,<<"eper">>,<<"0.94.0">>},0},

--- a/tree
+++ b/tree
@@ -1,6 +1,6 @@
 [0m├─ dalmatiner_db─0.2.0
 ├─ dalmatiner_vacuum─0.1.2
-├─ dproto─0.1.18
+├─ dproto─0.1.19
 ├─ edown─0.7.0
 ├─ eper─0.94.0
 ├─ fifo_utils─0.1.22


### PR DESCRIPTION
The approach is to set the bucket resolution in the riak metadata.  Since this cannot change once the bucket is created, it was necessary to first check if was already set, and if so, ensure the same value.  This may introduce a slight performance penalty (DETS lookup) for every Stream write with the additional resolution parameter.

Part of: https://github.com/dalmatinerdb/dalmatinerdb/issues/64
