### PR TITLE
Add support for stats refresh 

### DIFF
--- a/apps/dalmatiner_db/src/dalmatiner_console.erl
+++ b/apps/dalmatiner_db/src/dalmatiner_console.erl
@@ -16,6 +16,9 @@
               stats/1
              ]).
 
+stats(["-r" | Args]) ->
+    ok = dalmatiner_metrics:refresh(),
+    stats(Args);
 stats([]) ->
     {ok, L} = dalmatiner_metrics:get_list(),
     lists:foreach(

--- a/apps/dalmatiner_metric/src/bkt_dict.erl
+++ b/apps/dalmatiner_metric/src/bkt_dict.erl
@@ -2,7 +2,7 @@
 
 -include_lib("mmath/include/mmath.hrl").
 
--export([new/3, update_chash/1, flush/1, add/4, to_list/1]).
+-export([new/3, update_chash/1, flush/1, reset/1, add/4, to_list/1]).
 
 -export_type([bkt_dict/0]).
 
@@ -30,8 +30,12 @@ add(Metric, Time, Points, BD = #bkt_dict{ppf = PPF}) ->
 flush(BD = #bkt_dict{dict = Dict, w = W, n = N}) ->
     BD1 = #bkt_dict{nodes = Nodes} = update_chash(BD),
     metric:mput(Nodes, Dict, W, N),
-    BD1#bkt_dict{dict = dict:new()}.
+    reset(BD1).
 
+-spec reset(bkt_dict()) ->
+                 bkt_dict().
+reset(BD) ->
+    BD#bkt_dict{dict = dict:new()}.
 
 -spec update_chash(bkt_dict()) ->
                  bkt_dict().
@@ -60,4 +64,3 @@ to_list(#bkt_dict{dict = Dict}) ->
                           [Es | Acc]
                   end, [], Dict),
     lists:flatten(L).
-

--- a/apps/dalmatiner_metric/src/dalmatiner_metrics.erl
+++ b/apps/dalmatiner_metric/src/dalmatiner_metrics.erl
@@ -13,7 +13,7 @@
 -include_lib("mstore/include/mstore.hrl").
 
 %% API
--export([start_link/0, start/0, stop/0, get_list/0]).
+-export([start_link/0, start/0, stop/0, get_list/0, refresh/0]).
 
 -ignore_xref([start_link/0, start/0, stop/0, get_list/0]).
 
@@ -40,6 +40,10 @@
 %%--------------------------------------------------------------------
 start_link() ->
     gen_server:start_link({local, ?SERVER}, ?MODULE, [], []).
+
+-spec refresh() -> ok.
+refresh() ->
+    gen_server:call(?SERVER, refresh).
 
 get_list() ->
     gen_server:call(?SERVER, get_list).
@@ -100,10 +104,16 @@ init([]) ->
 %%                                   {stop, Reason, State}
 %% @end
 %%--------------------------------------------------------------------
+handle_call(refresh, _From, State = #state{prefix = Prefix, dict = Dict0}) ->
+    Dict = collect_metrics(Prefix, Dict0),
+    List = bkt_dict:to_list(Dict),
+    DictR = bkt_dict:reset(Dict),
+    {reply, ok, State#state{list = List,
+                                     dict = DictR}};
 handle_call(get_list, _From, State = #state{list = List}) ->
     List1 = [{dproto:metric_to_list(M), lists:nth(1, mmath_bin:to_list(V))}
              || {_, M, _, V} <- List],
-    {reply, {ok, List1}, State#state{running = true}};
+    {reply, {ok, List1}, State};
 handle_call(start, _From, State = #state{running = false}) ->
     erlang:send_after(?INTERVAL, self(), tick),
     Reply = ok,
@@ -143,35 +153,8 @@ handle_cast(_Msg, State) ->
 
 handle_info(tick,
             State = #state{running = true, prefix = Prefix, dict = Dict0}) ->
-    %% Initialize what we need
-    Dict = bkt_dict:update_chash(Dict0),
-    Time = timestamp(),
 
-    %% Add our own counters
-    Counts = ddb_counter:get_and_clean(),
-    DictC = lists:foldl(fun ({Name, Count}, Acc) ->
-                                add_metric(Prefix, metric_name(Name),
-                                           Time, Count, Acc)
-                        end, Dict, Counts),
-
-    %% Add our own histograms
-    Hists = ddb_histogram:get(),
-    DictH = lists:foldl(
-              fun ({Name, Vals}, Acc1) ->
-                      Pfx1 = [Prefix, metric_name(Name)],
-                      lists:foldl(
-                        fun({K, V}, Acc2) ->
-                                add_metric(Pfx1, [K], Time, V, Acc2)
-                        end, Acc1, Vals)
-              end, DictC, Hists),
-
-    %% Add folsom data to the dict
-    Spec = folsom_metrics:get_metrics_info(),
-    DictF = do_metrics(Prefix, Time, Spec, DictH),
-
-    %% Add riak_core related data
-    DictR = get_handoff_metrics(Prefix, Time, DictF),
-
+    DictR = collect_metrics(Prefix, Dict0),
 
     %% Keep a list with info
     AsList = bkt_dict:to_list(DictR),
@@ -184,15 +167,6 @@ handle_info(tick,
 
 handle_info(_Info, State) ->
     {noreply, State}.
-
-get_handoff_metrics(Prefix, Time, Dict) ->
-    Inbound = riak_core_handoff_manager:status({direction, inbound}),
-    Outbound = riak_core_handoff_manager:status({direction, outbound}),
-
-    Dict1 = add_to_dict([Prefix, <<"handoffs">>, <<"inbound">>],
-                        Time, length(Inbound), Dict),
-    add_to_dict([Prefix, <<"handoffs">>, <<"outbound">>],
-                Time, length(Outbound), Dict1).
 
 %%--------------------------------------------------------------------
 %% @private
@@ -222,6 +196,45 @@ code_change(_OldVsn, State, _Extra) ->
 %%%===================================================================
 %%% Internal functions
 %%%===================================================================
+
+collect_metrics(Prefix, Dict0) ->
+    %% Initialize what we need
+    Dict = bkt_dict:update_chash(Dict0),
+    Time = timestamp(),
+
+    %% Add our own counters
+    Counts = ddb_counter:get_and_clean(),
+    DictC = lists:foldl(fun ({Name, Count}, Acc) ->
+                                add_metric(Prefix, metric_name(Name),
+                                           Time, Count, Acc)
+                        end, Dict, Counts),
+
+    %% Add our own histograms
+    Hists = ddb_histogram:get(),
+    DictH = lists:foldl(
+              fun ({Name, Vals}, Acc1) ->
+                      Pfx1 = [Prefix, metric_name(Name)],
+                      lists:foldl(
+                        fun({K, V}, Acc2) ->
+                                add_metric(Pfx1, [K], Time, V, Acc2)
+                        end, Acc1, Vals)
+              end, DictC, Hists),
+
+    %% Add folsom data to the dict
+    Spec = folsom_metrics:get_metrics_info(),
+    DictF = do_metrics(Prefix, Time, Spec, DictH),
+
+    %% Add riak_core related data
+    get_handoff_metrics(Prefix, Time, DictF).
+
+get_handoff_metrics(Prefix, Time, Dict) ->
+    Inbound = riak_core_handoff_manager:status({direction, inbound}),
+    Outbound = riak_core_handoff_manager:status({direction, outbound}),
+
+    Dict1 = add_to_dict([Prefix, <<"handoffs">>, <<"inbound">>],
+                        Time, length(Inbound), Dict),
+    add_to_dict([Prefix, <<"handoffs">>, <<"outbound">>],
+                Time, length(Outbound), Dict1).
 
 %do_metrics(CBin, Time, Specs, Acc) ->
 do_metrics(_Prefix, _Time, [], Acc) ->


### PR DESCRIPTION
… that gets fresh stats even if metrics collection is not started.

I havne't tested it yet, but I would like to hear your early feedback, whether you find this acceptable.

With this patch we could run ddb with self monitoring disabled and we would schedule flushing loop externally, by calls to 

```ddb-admin stats -r```

Plain stats would keep existing functionality so one can still peek at last stats without triggering reset.